### PR TITLE
Add: Extra control for bad response & More spreadsheet information

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -341,9 +341,29 @@ Spreadsheet.prototype.receive = function(callback) {
       return;
     }
 
+    var wsTitle = result.feed.title.$t || null;
+    var wsUpdated = result.feed.updated.$t || null;
+    var authors = [];
+
+    if(result.feed.author instanceof Array) {
+      var authorCnt = result.feed.author.length;
+
+      for(var i = 0; i < authorCnt; i++) {
+        authors[i] = {
+          "name": result.feed.author[i].name.$t || null,
+          "email": result.feed.author[i].email.$t || null
+        };
+      };
+    }
+
     var entries = result.feed.entry || [];
     var rows = {};
     var info = {
+      spreadsheetId: _this.spreadsheetId,
+      worksheetId: _this.worksheetId,
+      worksheetTitle: wsTitle,
+      worksheetUpdated: wsUpdated,
+      authors: authors,
       totalCells: entries.length,
       totalRows: 0,
       lastRow: 1,
@@ -374,4 +394,3 @@ Spreadsheet.prototype.receive = function(callback) {
   });
 
 };
-


### PR DESCRIPTION
Extra control for bad response: "JSON.parse(body);" cause an error ("SyntaxError: Unexpected token...") due body's value. Because it is just a string message (for example: "Invalid query parameter value for grid-id.") if the request/response is not successful.

More spreadsheet information: spreadsheetId, worksheetId, worksheetTitle, worksheetUpdated, authors
