### PR TITLE
Adding support for creation of missing spreadsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ Whether to use `https` when connecting to Google (default: `true`)
 
 #### Todo
 
-* Create New Spreadsheets
 * Read specific range of cells
 * Option to cache auth token in file
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,18 +2,18 @@ var GoogleClientLogin = require('googleclientlogin').GoogleClientLogin;
 var GoogleOAuthJWT = require('google-oauth-jwt');
 
 //client auth helper
-module.exports = function(opts, done) {
+module.exports = function(opts, service, done) {
   if(opts.username && opts.password)
-    clientLogin(opts.username, opts.password, done);
+    clientLogin(opts.username, opts.password, service, done);
   else if(opts.oauth)
-    oauthLogin(opts.oauth, opts.useHTTPS, done);
+    oauthLogin(opts.oauth, opts.useHTTPS, service, done);
 };
 
-function clientLogin(username, password, done) {
+function clientLogin(username, password, service, done) {
   var googleAuth = new GoogleClientLogin({
     email: username,
     password: password,
-    service: 'spreadsheets',
+    service: service,
     accountType: GoogleClientLogin.accountTypes.google
   });
   //error - show and exit
@@ -27,10 +27,10 @@ function clientLogin(username, password, done) {
   googleAuth.login();
 }
 
-function oauthLogin(oauth, useHTTPS, done) {
+function oauthLogin(oauth, useHTTPS, service,done) {
 
   if(!oauth.scopes)
-    oauth.scopes = ['http'+useHTTPS+'://spreadsheets.google.com/feeds'];
+    oauth.scopes = ['http'+useHTTPS+'://'+service+'.google.com/feeds'];
 
   GoogleOAuthJWT.authenticate(oauth, function (err, token) {
     if(err)

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,8 @@ exports.create = function(opts) {
     return opts.callback("Missing 'spreadsheetId' or 'spreadsheetName'");
   if(!opts.worksheetId  && !opts.worksheetName)
     return opts.callback("Missing 'worksheetId' or 'worksheetName'");
-
+  if(!opts.create_new && opts.worksheetName !== 'Sheet 1')
+     return opts.callback("Worksheet must be named Sheet 1 when creating new Spreadsheet");
   var spreadsheet = new Spreadsheet();
 
   //default to http's' when undefined
@@ -31,11 +32,32 @@ exports.create = function(opts) {
     'worksheetId', 'worksheetName', 'debug'
   ));
 
-  spreadsheet.log('Logging into Google...'.grey);
-  auth(opts, function(err, token) {
+  spreadsheet.log('Logging into Google Spreadsheets API...'.grey);
+  auth(opts,'spreadsheets', function(err, token) {
     if(err) return opts.callback(err);
-    spreadsheet.log('Logged into Google'.green);
-    spreadsheet.init(token, opts.callback);
+    spreadsheet.log('Logged into Google Spreadsheets API'.green);
+    spreadsheet.init(token, function(err){
+      if(err && err.match(/spread(.*?)not found$/) && opts.create_new) {
+        spreadsheet.log(err.grey);
+        spreadsheet.log('Creating new spreadsheet'.grey);
+        spreadsheet.log('Logging into Google Docs API'.grey);
+        auth(opts, "docs", function(err, docsToken) {
+          if(err) return opts.callback(err);
+          spreadsheet.log('Logged into Google Docs API'.green);
+          spreadsheet.createNew(docsToken.token,function(err,response,body){
+            console.log(body);
+            if(err) return opts.callback(err);
+            if(!JSON.parse(body).entry) return opts.callback("There was en error creating a new spreadsheet: "+body);
+            spreadsheet.log('New Spreadsheet successfully created'.grey);
+            spreadsheet.init(token, function(err) {
+              opts.callback(err,spreadsheet);
+            });
+          });
+        });
+      } else {
+        opts.callback(err,spreadsheet);
+      }
+    });
   });
 };
 
@@ -273,6 +295,24 @@ Spreadsheet.prototype.compile = function() {
     }
 
   return strs.join('\n');
+};
+
+Spreadsheet.prototype.createNew = function(token, callback) {
+  request({
+    method: 'POST',
+    url: 'https://docs.google.com/feeds/default/private/full?alt=json',
+    headers: {
+      'Authorization': 'GoogleLogin auth=' + token,
+      'Content-Type': 'application/atom+xml',
+      'GData-Version': '3.0'
+    },
+    body: '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<entry xmlns="http://www.w3.org/2005/Atom" xmlns:docs="http://schemas.google.com/docs/2007">' +
+    '<category scheme="http://schemas.google.com/docs/2007#spreadsheet" term="http://schemas.google.com/docs/2007#spreadsheet"/>' +
+    '<title>'+ this.spreadsheetName + '</title>' +
+    '</entry>'
+  },
+  callback);
 };
 
 Spreadsheet.prototype.send = function(callback) {


### PR DESCRIPTION
Now when a sheet cannot be found, the api will log into the docs api and create a sheet.
This is off by default and you will need to have "create_new: true" to your opts to to switch it on.

The creation of sheets is currently not supported (and you need to use Sheet 1), however who knows maybe that can be another todo.
