### PR TITLE
Extend package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,6 @@
     "request": "~2.21.0",
     "google-oauth-jwt": "0.0.4",
     "async": "~0.2.9"
-  }
+  },
+  "repository":"git://github.com/jpillora/node-edit-google-spreadsheet.git"
 }


### PR DESCRIPTION
- Fix error because of missing async.
- Add information to make code discovery easier when on npmjs.org for example.
