### PR TITLE
Fixing for date values.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -18,10 +18,17 @@ exports.int2cell = function(r,c) {
 //convert '=RC[-2]+R[3]C[-1]' (on r:5 c:4) to '=B5+C8'
 exports.gcell2cell = function(cell) {
   if(!/^=/.test(cell.inputValue))
-    if(cell.numericValue)
-      return exports.num(cell.numericValue);
-    else
+    if(cell.numericValue) {
+      if(cell.numericValue !== cell.inputValue && !isNaN(Date.parse(cell.inputValue))) {
+        return cell.inputValue;
+      }
+      else {
+        return exports.num(cell.numericValue);
+      }
+    }
+    else {
       return cell.inputValue;
+    }
 
   return cell.inputValue.replace(/(R(\[(-?\d+)\])?)(C(\[(-?\d+)\])?)/g, function() {
     return exports.int2cell(


### PR DESCRIPTION
There is an issue with date fields. `numericValue` is not human readable. Here is an example dump data;

``` jacascript
{ row: '1',
  col: '1',
  inputValue: '12/11/2013 11:28:59',
  numericValue: '41619.47846064815',
  '$t': '12/11/2013 11:28:59' }
```

This commit fixes this issue.
