### PR TITLE
Add: Create spreadsheet from access token, bypassing auth client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ Create sheet with OAuth:
   });
 ```
 
+Create sheet with an Access Token:
+
+``` js
+  var Spreadsheet = require('edit-google-spreadsheet');
+
+  Spreadsheet.create({
+    debug: true,
+    accessToken : {
+        type: 'Bearer',
+        token: 'some_oauth_generated_access_token'
+    },
+    spreadsheetName: 'node-edit-spreadsheet',
+    worksheetName: 'Sheet1',
+    callback: sheetReady
+  });
+```
+
 Update sheet:
 
 ``` js

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -7,6 +7,8 @@ module.exports = function(opts, done) {
     clientLogin(opts.username, opts.password, done);
   else if(opts.oauth)
     oauthLogin(opts.oauth, opts.useHTTPS, done);
+  else if(opts.accessToken)
+    accessTokenLogin(opts.accessToken.type, opts.accessToken.token, done);
 };
 
 function clientLogin(username, password, done) {
@@ -38,4 +40,11 @@ function oauthLogin(oauth, useHTTPS, done) {
     else
       done(null, {type : 'Bearer', token :  token});
   });
+}
+
+function accessTokenLogin(type, token, done) {
+  if(!type || !token)
+    done("Missing token or token type information");
+
+  done(null, {type : type, token : token});
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ exports.create = function(opts) {
 
   if(!opts.callback)
     throw "Missing callback";
-  if(!(opts.username && opts.password) && !opts.oauth)
+  if(!(opts.username && opts.password) && !opts.oauth && !opts.accessToken)
     return opts.callback("Missing authentication information");
   if(!opts.spreadsheetId  && !opts.spreadsheetName)
     return opts.callback("Missing 'spreadsheetId' or 'spreadsheetName'");


### PR DESCRIPTION
I'm using google's 'googleapis' module to generate an access token so I don't need the client portion of the auth module. Since I didn't find a way to do this using your module I'm submitting this pull request.

It includes:
    - An auth method to ensure that if the access token is provided then both parts (type and token) are included and it bypasses the client login, or jwt login.
    - Validation in index.js so opts.accessToken is included in the validation step.
    - Update to the readme with a usage example.
