### PR TITLE
Adds docs.google.com/feeds to default OAuth scopes

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -31,8 +31,12 @@ function clientLogin(username, password, done) {
 
 function oauthLogin(oauth, useHTTPS, done) {
 
-  if(!oauth.scopes)
-    oauth.scopes = ['http'+useHTTPS+'://spreadsheets.google.com/feeds'];
+  if(!oauth.scopes) {
+    oauth.scopes = [
+      'http'+useHTTPS+'://spreadsheets.google.com/feeds',
+      'http'+useHTTPS+'://docs.google.com/feeds'
+    ];
+  }
 
   GoogleOAuthJWT.authenticate(oauth, function (err, token) {
     if(err)


### PR DESCRIPTION
When using OAuth, it's apparently now necessary to pass an additional scope to the JWT auth request:
`https://docs.google.com/feeds`

Without it, requests for spreadsheet data 404, yielding downstream errors like:

```
TypeError: Cannot read property 'feed' of undefined
  at /your-app/node_modules/edit-google-spreadsheet/lib/index.js:421:15
```

Caveat: I have not seen any documentation from Google about this change. It is possible that it's unintended on their part. At the moment, their own [OAuth Playground](https://developers.google.com/oauthplayground/) returns 404s for spreadsheet API requests built with the wizard –  unless you manually add the `https://docs.google.com/feeds` scope.

![screen shot 2014-04-30 at 9 58 04 am](https://cloud.githubusercontent.com/assets/141130/2842043/d918c550-d06f-11e3-9747-bb735aee91a2.png)

See also this [stackoverflow thread](http://stackoverflow.com/a/23385092) from the past 12 hours.
