### PR TITLE
Pr response format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var auth = require("./auth");
 var util = require("./util");
 var Metadata = require('./metadata');
 var async = require('async');
+var xmlutil= require('xml2json');
 
 //public api
 exports.create = exports.load = function(opts, callback) {
@@ -102,18 +103,24 @@ Spreadsheet.prototype.request = function(opts, callback) {
     //body is error
     if(response.statusCode !== 200)
       return callback(body);
-    //if we requested JSON, parse it
-    if(opts.url.indexOf("alt=json") !== -1) {
-      var result;
+	
+    // 1. Try to parse JSON
+    // 2. If invalid, assume it is XML, turn into JSON and parse it
+    // 3. If still invalid, raise error
+    var result;
+    
+    try {
+      result = JSON.parse(body);
+    } catch(e) {
       try {
-        result = JSON.parse(body);
+        result = JSON.parse(xmlutil.toJson(body));
       } catch(e) {
-        return callback("JSON Parse Error: " + e);
+        return callback('Bad response format (' + e + ')');
       }
-      return callback(null, result);
     }
+    
+    return callback(null, result);
 
-    return callback(null, body);
   });
 };
 
@@ -134,11 +141,17 @@ Spreadsheet.prototype.getSheetId = function(type, callback) {
 
   this.request({
     url: this.protocol+'://spreadsheets.google.com/feeds/'+
-         type+'sheets'+spreadsheetUrlId+'/private/full?alt=json'
+         type+'sheets'+spreadsheetUrlId+'/private/full'
   }, function(err, result) {
     if(err) return callback(err);
 
     var entries = result.feed.entry || [];
+	
+	// Force array format for result
+	if (!(entries instanceof Array)) {
+	  entries = [entries];
+	}
+	
     //store raw mapped results
     _this.raw[type+'sheets'] = entries.map(function(e1) {
       var e2 = {};
@@ -409,9 +422,8 @@ Spreadsheet.prototype.receive = function(options, callback) {
   var _this = this;
   // get whole spreadsheet
   this.request({
-    url: this.baseUrl()+'?alt=json'
+    url: this.baseUrl()
   }, function(err, result) {
-
     if(!result.feed) {
       err = "Error Reading Spreadsheet";
       _this.log(
@@ -428,9 +440,7 @@ Spreadsheet.prototype.receive = function(options, callback) {
       worksheetId: _this.worksheetId,
       worksheetTitle: result.feed.title.$t || null,
       worksheetUpdated: new Date(result.feed.updated.$t) || null,
-      authors: result.feed.author && result.feed.author.map(function(author) {
-        return { name: author.name.$t, email: author.email.$t };
-      }),
+      authors: result.feed.author && result.feed.author.name,
       totalCells: entries.length,
       totalRows: 0,
       lastRow: 1,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lodash": "~1.2.1",
     "request": "~2.21.0",
     "google-oauth-jwt": "0.0.4",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "xml2json": "~0.4.0"
   },
   "repository": "git://github.com/jpillora/node-edit-google-spreadsheet.git"
 }


### PR DESCRIPTION
To avoid having to handle JSON or XML response format according to document version, I added a xml2json conversion in request method, called only if JSON parsing fails.

This solved for me all problems I see in #29 discussion, although this may not be the best workaround...
