### PR TITLE
Fixes worksheetTitle and worksheetUpdated being null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -438,8 +438,8 @@ Spreadsheet.prototype.receive = function(options, callback) {
     var info = {
       spreadsheetId: _this.spreadsheetId,
       worksheetId: _this.worksheetId,
-      worksheetTitle: result.feed.title.$t || null,
-      worksheetUpdated: new Date(result.feed.updated.$t) || null,
+      worksheetTitle: result.feed.title.$t || result.feed.title || null,
+      worksheetUpdated: new Date(result.feed.updated.$t || result.feed.updated) || null,
       authors: result.feed.author && result.feed.author.name,
       totalCells: entries.length,
       totalRows: 0,


### PR DESCRIPTION
When receiving Worksheet info, worksheetTitle was null and
worksheetUpdated was an invalid date. result.feed.title.$t and
result.feed.updated.$t does not exist which causes the issue.
