### PR TITLE
If sheet is unreadable, trigger error (rather than crash)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -424,7 +424,7 @@ Spreadsheet.prototype.receive = function(options, callback) {
   this.request({
     url: this.baseUrl()
   }, function(err, result) {
-    if(!result.feed) {
+    if(!result || !result.feed) {
       err = "Error Reading Spreadsheet";
       _this.log(
         err.red.underline +


### PR DESCRIPTION
If `result` is undefined, then Node will throw a TypeError when trying to access `result.feed`.

This small fix should make sure that the descriptive error will be triggered, instead of ending the script altogether.
