### PR TITLE
Force the entries to be an array

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -468,6 +468,10 @@ Spreadsheet.prototype.receive = function(options, callback) {
     }
 
     var entries = result.feed.entry || [];
+    // Force array format for result
+    if (!(entries instanceof Array)) {
+      entries = [entries];
+    }
     var rows = {};
     var info = {
       spreadsheetId: _this.spreadsheetId,


### PR DESCRIPTION
In the spreadsheet receive call, if there is only a single cell in the spreadsheet, result.feed.entry will be a single record, and the subsequent iteration over entries will instead iterate over object properties.

This leads to:
TypeError: Cannot read property 'row' of undefined

This patch forces the entries to be an array.
