### PR TITLE
Use the xml endpoint, which is still supported, rather than the json var...

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -12,17 +12,17 @@ Metadata.prototype.url = function(isId) {
 
 Metadata.prototype.extract = function(result) {
   return {
-    updated: new Date(result.entry.updated.$t),
-    title: result.entry.title.$t,
-    rowCount: parseInt(result.entry.gs$rowCount.$t, 10),
-    colCount: parseInt(result.entry.gs$colCount.$t, 10)
+    updated: new Date(result.entry.updated),
+    title: result.entry.title,
+    rowCount: result.entry['gs:rowCount'],
+    colCount: result.entry['gs:colCount']
   };
 };
 
 Metadata.prototype.get = function(callback) {
   var _this = this;
   this.spreadsheet.request({
-    url: this.url()+'?alt=json'
+    url: this.url()
   }, function(err, result) {
     if(err) return callback(err);
     callback(null, _this.extract(result));
@@ -53,7 +53,7 @@ Metadata.prototype._set = function(data, callback) {
 
   this.spreadsheet.request({
     method: 'PUT',
-    url: this.url()+'?alt=json',
+    url: this.url(),
     body: entry
   }, function(err, result) {
     if(err) return callback(err);


### PR DESCRIPTION
While old documents may still support a json api, new documents will only return xml. This change gets the xml, and handles the slightly different structure of the object returned by the xmlutil conversion (in spreadsheet.request from index.js).