### PR TITLE
Added support for authenticating using OAuth2 and a refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Load a spreadsheet:
     spreadsheetName: 'node-edit-spreadsheet',
     worksheetName: 'Sheet1',
 
-    // Choose from 1 of the 4 authentication methods:
-    
+    // Choose from 1 of the 5 authentication methods:
+
     //    1. Username and Password has been deprecated
 
     // OR 2. OAuth
@@ -39,13 +39,20 @@ Load a spreadsheet:
       keyFile: 'my-private-key.pem'
     },
 
-    // OR 3. Static Token
+    // OR 3. OAuth2
+    oauth2: {
+      client_id: 'generated-id.apps.googleusercontent.com',
+      client_secret: 'generated-secret',
+      refresh_token: 'token generated with get_oauth2_permission.js'
+    },
+
+    // OR 4. Static Token
     accessToken: {
       type: 'Bearer',
       token: 'my-generated-token'
     },
 
-    // OR 4. Dynamic Token
+    // OR 5. Dynamic Token
     accessToken: function(callback) {
       //... async stuff ...
       callback(null, token);

--- a/example/get_oauth2_permission.js
+++ b/example/get_oauth2_permission.js
@@ -1,0 +1,72 @@
+// Based on https://raw.githubusercontent.com/google/google-api-nodejs-client/master/examples/oauth2.js
+// Adapted by Oystein Steimler <oystein@nyvri.net>
+
+/**
+ * Copyright 2012 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var readline = require('readline');
+
+var google = require('googleapis');
+var OAuth2Client = google.auth.OAuth2;
+
+// Client ID and client secret are available at
+// https://code.google.com/apis/console
+// 1. Create or pick a project
+// 2. Choose "API & Auth" and then "Credentials"
+// 3. Click "Create new Client ID"
+// 4. Select "Installed application" and "Other"
+// 5. Copy your ClientID and Client Secret into the fields beneath
+
+var CLIENT_ID = '';
+var CLIENT_SECRET = '';
+
+// 6. Check if readonly permission is ok, if not change to 'https://www.googleapis.com/auth/drive'
+//    ..Or find the correct scope you need here: https://developers.google.com/drive/web/scopes
+
+var PERMISSION_SCOPE = 'https://www.googleapis.com/auth/drive.readonly'; // can be a space-delimited string or an array of scopes
+
+// 6. Run this script: `node example/get_oauth2_permission.js'
+// 7. Visit the URL printed, authenticate the google user, grant the permission
+// 8. Copy the authorization code and paste it at the prompt of this program.
+// 9. The refresh_token you get is needed with the client_id and client_secret when using edit-google-spreadsheet
+
+
+
+var oauth2Client = new OAuth2Client(CLIENT_ID, CLIENT_SECRET, 'urn:ietf:wg:oauth:2.0:oob');
+
+var rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+// generate consent page url
+var url = oauth2Client.generateAuthUrl({
+  access_type: 'offline', // will return a refresh token
+  scope: PERMISSION_SCOPE });
+
+console.log('Visit the url: ', url);
+rl.question('Enter the code here:', function(code) {
+  // request access token
+  oauth2Client.getToken(code, function(err, tokens) {
+    console.log('\nYour refrehs_token is %s\n', tokens.refresh_token);
+
+    console.log( 'Use this in your Spreadsheet.load():\noauth2: %s',
+      JSON.stringify( { client_id: CLIENT_ID, client_secret: CLIENT_SECRET, refresh_token: tokens.refresh_token }, true, 2 ) );
+
+    process.exit()
+  });
+});
+

--- a/example/oauth2.js
+++ b/example/oauth2.js
@@ -1,0 +1,29 @@
+// Example of OAuth2 login using "Client ID for native application" and a
+// refresh token of an oauth2 grant.
+//
+// To prepare the refresh_token, please se the get_oauth2_permission.js
+//
+
+var Spreadsheet = require('../');
+
+Spreadsheet.load({
+  debug: true,
+  oauth2: {
+    client_id : '<garbage>.apps.googleusercontent.com',
+    client_secret : '<more garbage>',
+    refresh_token : '<even more garbage>'
+  },
+  spreadsheetName: 'node-edit-spreadsheet',
+  worksheetName:   'Sheet1',
+  // spreadsheetId: 'ttFmrFPIipJimDQYSFyhwTg',
+  // worksheetId: "od6"
+}, function run(err, spreadsheet) {
+  if(err) throw err;
+  //receive all cells
+  spreadsheet.receive({getValues:false},function(err, rows, info) {
+    if(err) throw err;
+    console.log("Found rows:", rows);
+    console.log("With info:", info);
+  });
+});
+

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,5 +1,6 @@
 var GoogleClientLogin = require('googleclientlogin').GoogleClientLogin;
 var GoogleOAuthJWT = require('google-oauth-jwt');
+var GoogleOAuthClient = require('googleapis').auth.OAuth2;
 
 //client auth helper
 module.exports = function(opts, done) {
@@ -7,6 +8,8 @@ module.exports = function(opts, done) {
     clientLogin(opts.username, opts.password, done);
   else if(opts.oauth)
     oauthLogin(opts.oauth, opts.useHTTPS, done);
+  else if(opts.oauth2)
+    oAuth2Login(opts.oauth2, done);
   else if(opts.accessToken)
     accessTokenLogin(opts.accessToken, done);
 };
@@ -40,6 +43,25 @@ function oauthLogin(oauth, useHTTPS, done) {
       done("Google OAuth Error: " + err);
     else
       done(null, {type : 'Bearer', token :  token});
+  });
+}
+
+function oAuth2Login(oauth2, done ) {
+
+  var oAuth2Client = new GoogleOAuthClient(oauth2.client_id, oauth2.client_secret, 'urn:ietf:wg:oauth:2.0:oob');
+
+  oAuth2Client.setCredentials({
+    access_token: 'DUMMY',
+    expiry_date: 1,
+    refresh_token: oauth2.refresh_token,
+    token_type: 'Bearer'
+  });
+
+  oAuth2Client.getAccessToken(function(err, token) {
+    if (err)
+      done('Google OAuth2 Error: ' + err);
+    else
+      done(null, {type: 'Bearer', token: token });
   });
 }
 

--- a/lib/spreadsheet.js
+++ b/lib/spreadsheet.js
@@ -16,7 +16,7 @@ exports.create = exports.load = function(opts, callback) {
     callback = opts.callback;
   if (!callback)
     throw "Missing callback";
-  if (!(opts.username && opts.password) && !opts.oauth && !opts.accessToken)
+  if (!(opts.username && opts.password) && !opts.oauth && !opts.oauth2 && !opts.accessToken)
     return callback("Missing authentication information");
   if (!opts.spreadsheetId && !opts.spreadsheetName)
     return callback("Missing 'spreadsheetId' or 'spreadsheetName'");

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "async": "^0.9.0",
     "colors": "~0.6.0-1",
     "google-oauth-jwt": "0.0.4",
+    "googleapis": "2.0.4",
     "googleclientlogin": "~0.2.6",
     "lodash": "^2.4.1",
     "request": "^2.51.0",


### PR DESCRIPTION
To be able to authenticate with the Google API when username/password login is disabled, I've created an auth mechanism which is based on Google API Client ID and permissions given, as a single-shot task, through a normal Google Consent screen.

Granting the permission to read or write files on Google Drive, renders a refresh_token, which can be used to authenticate as the user giving the permission. This user should be identical to the one indentified by username/password earlier, to give the same effect.