### PR TITLE
Node v4.0 compatibility : replace xml2json with xml2js

### DIFF
--- a/lib/spreadsheet.js
+++ b/lib/spreadsheet.js
@@ -8,7 +8,7 @@ var auth = require("./auth");
 var util = require("./util");
 var Metadata = require('./metadata');
 var async = require('async');
-var xmlutil = require('xml2json');
+var xml2js = require('xml2js');
 
 //public api
 exports.create = exports.load = function(opts, callback) {
@@ -52,6 +52,12 @@ function Spreadsheet(opts) {
   this.opts = opts;
   this.raw = {};
   this.protocol = 'http';
+  this.xmlParser = new xml2js.Parser({
+    charkey: '$t',
+    explicitArray: false,
+    explicitCharkey: false,
+    mergeAttrs: true
+  });
   this.reset();
 }
 
@@ -114,14 +120,7 @@ Spreadsheet.prototype.request = function(opts, callback) {
       return callback(body);
 
     //try to parse XML
-    var result;
-    try {
-      result = xmlutil.toJson(body, {object: true, sanitize: false, trim: false});
-    } catch (e) {
-      return callback('Bad response format (' + e + ')');
-    }
-
-    return callback(null, result);
+    _this.xmlParser.parseString(body, callback);
   });
 };
 
@@ -166,9 +165,9 @@ Spreadsheet.prototype.getSheetId = function(type, callback) {
         }
         //remove silly gs$
         if (/^g[a-z]\$(\w+)/.test(prop))
-          e2[RegExp.$1] = val;
+          e2[RegExp.$1] = isNaN(Number(val)) ? val : Number(val);
         else
-          e2[prop] = val;
+          e2[prop] = isNaN(Number(val)) ? val : Number(val);
       }
       //search for 'name', extract only end portion of URL!
       if (e2.title === name && e2.id && /([^\/]+)$/.test(e2.id))
@@ -434,7 +433,7 @@ Spreadsheet.prototype.send = function(options, callback) {
           });
 
           //concat error messages
-          var msg = "Error updating spreadsheet: " + 
+          var msg = "Error updating spreadsheet: " +
             errors.map(function(e, i) {
               // var msg = errors.length > 1 ? ("#"+(i+1)) : "";
               var msg = e.status.reason;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "googleclientlogin": "~0.2.6",
     "lodash": "^2.4.1",
     "request": "^2.51.0",
-    "xml2json": "^0.6.1"
+    "xml2js": "^0.4.0"
   },
   "repository": "git://github.com/jpillora/node-edit-google-spreadsheet.git"
 }


### PR DESCRIPTION
Hi,
I was unable to migrate my project to Node v4.0 because of the dependency to xml2json that is a lot of trouble due to its dependency to node-expat.
So I replaced it with xml2js that is lighter and fully compatible with Node v4.0.