### PR TITLE
Replaced xml2json with xml2js

### DIFF
--- a/lib/spreadsheet.js
+++ b/lib/spreadsheet.js
@@ -8,7 +8,7 @@ var auth = require("./auth");
 var util = require("./util");
 var Metadata = require('./metadata');
 var async = require('async');
-var xmlutil = require('xml2json');
+var xml2js = require('xml2js');
 
 //public api
 exports.create = exports.load = function(opts, callback) {
@@ -52,6 +52,12 @@ function Spreadsheet(opts) {
   this.opts = opts;
   this.raw = {};
   this.protocol = 'http';
+  this.xmlParser = new xml2js.Parser({
+    charkey: '$t',
+    explicitArray: false,
+    explicitCharkey: false,
+    mergeAttrs: true
+  });
   this.reset();
 }
 
@@ -114,14 +120,7 @@ Spreadsheet.prototype.request = function(opts, callback) {
       return callback(body);
 
     //try to parse XML
-    var result;
-    try {
-      result = xmlutil.toJson(body, {object: true, sanitize: false, trim: false});
-    } catch (e) {
-      return callback('Bad response format (' + e + ')');
-    }
-
-    return callback(null, result);
+    _this.xmlParser.parseString(body, callback);
   });
 };
 
@@ -166,9 +165,9 @@ Spreadsheet.prototype.getSheetId = function(type, callback) {
         }
         //remove silly gs$
         if (/^g[a-z]\$(\w+)/.test(prop))
-          e2[RegExp.$1] = val;
+          e2[RegExp.$1] = isNaN(Number(val)) ? val : Number(val);
         else
-          e2[prop] = val;
+          e2[prop] = isNaN(Number(val)) ? val : Number(val);
       }
       //search for 'name', extract only end portion of URL!
       if (e2.title === name && e2.id && /([^\/]+)$/.test(e2.id))
@@ -434,7 +433,7 @@ Spreadsheet.prototype.send = function(options, callback) {
           });
 
           //concat error messages
-          var msg = "Error updating spreadsheet: " + 
+          var msg = "Error updating spreadsheet: " +
             errors.map(function(e, i) {
               // var msg = errors.length > 1 ? ("#"+(i+1)) : "";
               var msg = e.status.reason;

--- a/lib/spreadsheet.js
+++ b/lib/spreadsheet.js
@@ -56,7 +56,9 @@ function Spreadsheet(opts) {
     charkey: '$t',
     explicitArray: false,
     explicitCharkey: false,
-    mergeAttrs: true
+    mergeAttrs: true,
+    valueProcessors: [xml2js.processors.parseNumbers],
+    attrValueProcessors: [xml2js.processors.parseNumbers],
   });
   this.reset();
 }
@@ -401,6 +403,7 @@ Spreadsheet.prototype.send = function(options, callback) {
         url: _this.baseUrl() + '/batch',
         body: body
       }, function(err, result) {
+
         var status = null;
 
         if (err)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "edit-google-spreadsheet",
   "version": "0.2.19",
+  "scripts": {
+    "test": "mocha test --recursive"
+  },
   "dependencies": {
     "async": "^0.9.0",
     "colors": "^1.0.3",
@@ -9,7 +12,14 @@
     "googleclientlogin": "~0.2.6",
     "lodash": "^2.4.1",
     "request": "^2.51.0",
-    "xml2js": "^0.4.0"
+    "xml2js": "git://github.com/TimJohns/node-xml2js.git#master"
   },
-  "repository": "git://github.com/jpillora/node-edit-google-spreadsheet.git"
+  "repository": "git://github.com/jpillora/node-edit-google-spreadsheet.git",
+  "devDependencies": {
+    "chai": "^3.3.0",
+    "mocha": "^2.3.3",
+    "mockery": "^1.4.0",
+    "sinon": "^1.17.1",
+    "sinon-chai": "^2.8.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "googleclientlogin": "~0.2.6",
     "lodash": "^2.4.1",
     "request": "^2.51.0",
-    "xml2js": "git://github.com/TimJohns/node-xml2js.git#master"
+    "xml2js": "git://github.com/TillerHQ/node-xml2js.git#master"
   },
   "repository": "git://github.com/jpillora/node-edit-google-spreadsheet.git",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "googleclientlogin": "~0.2.6",
     "lodash": "^2.4.1",
     "request": "^2.51.0",
-    "xml2js": "git://github.com/TillerHQ/node-xml2js.git#master"
+    "xml2js": "^0.4.15"
   },
   "repository": "git://github.com/jpillora/node-edit-google-spreadsheet.git",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "googleclientlogin": "~0.2.6",
     "lodash": "^2.4.1",
     "request": "^2.51.0",
-    "xml2json": "^0.6.1"
+    "xml2js": "^0.4.0"
   },
   "repository": "git://github.com/jpillora/node-edit-google-spreadsheet.git"
 }

--- a/test/spreadsheet.js
+++ b/test/spreadsheet.js
@@ -64,31 +64,28 @@ describe('Spreadsheet', function() {
     it('should throw an error if there is no callback', function() {
       expect(function() {
         Spreadsheet.create({});
-      }).to.throw(Error)
+      }).to.throw('Missing callback')
     });
     it('should return an error if there is no auth mechanism', function() {
       var errValue;
       var callback = sinon.spy(function(err) {errValue = err;});
       Spreadsheet.create({spreadsheetId: 'spreadsheetId', worksheetId: 'worksheetId'}, callback);
       expect(callback).to.have.been.calledOnce;
-      expect(errValue).to.be.an.instanceof(Error);
-      expect(Error.message).to.equal('Missing authentication information');
+      expect(errValue).to.equal('Missing authentication information');
     });
     it('should return an error if there is no spreadsheet specified', function() {
       var errValue;
       var callback = sinon.spy(function(err) {errValue = err;});
       Spreadsheet.create({oauth2: 'oauth2', worksheetId: 'worksheetId'}, callback);
       expect(callback).to.have.been.calledOnce;
-      expect(errValue).to.be.an.instanceof(Error);
-      expect(Error.message).to.equal("Missing 'spreadsheetId' or 'spreadsheetName'");
+      expect(errValue).to.equal("Missing 'spreadsheetId' or 'spreadsheetName'");
     });
     it('should return an error if there is no worksheet specified', function() {
       var errValue;
       var callback = sinon.spy(function(err) {errValue = err;});
       Spreadsheet.create({oauth2: 'oauth2', spreadsheetId: 'spreadsheetId'}, callback);
       expect(callback).to.have.been.calledOnce;
-      expect(errValue).to.be.an.instanceof(Error);
-      expect(Error.message).to.equal("Missing 'worksheetId' or 'worksheetName'");
+      expect(errValue).to.equal("Missing 'worksheetId' or 'worksheetName'");
     });
     describe('when authing with defaults', function() {
       var authParams;
@@ -172,7 +169,7 @@ describe('Spreadsheet', function() {
       });
       it('should return an error if no URL is provided', function(done) {
         spreadsheet.request({}, function(err, response) {
-          expect(err).to.be.an.instanceof(Error);
+          expect(err).to.equal('Invalid request');
           done();
         });
       });
@@ -186,14 +183,7 @@ describe('Spreadsheet', function() {
       it('should return an error if the server does not respond', function(done) {
         mockRequestCbParams.response = undefined;
         spreadsheet.request(opts, function(err, response) {
-          expect(err).to.be.an.instanceof(Error);
-          done();
-        });
-      });
-      it('should return an error if the server returns with an unexpected content type', function(done) {
-        mockRequestCbParams.response.headers = { 'content-type': 'image/svg+xml; charset=utf-8' };
-        spreadsheet.request(opts, function(err, response) {
-          expect(err).to.be.an.instanceof(Error);
+          expect(err).to.equal('no response');
           done();
         });
       });
@@ -201,8 +191,7 @@ describe('Spreadsheet', function() {
         mockRequestCbParams.response.statusCode = 500;
         mockRequestCbParams.body = 'Something broke.';
         spreadsheet.request(opts, function(err, response) {
-          expect(err).to.be.an.instanceof(Error);
-          expect(err.message).to.be('Something broke.');
+          expect(err).to.equal('Something broke.');
           done();
         });
       });
@@ -259,59 +248,6 @@ describe('Spreadsheet', function() {
           done();
         });
       });
-    });
-    describe('init', function(done) {
-      it('should get the spreadsheet id', function() {
-        mockRequest.reset();
-        Spreadsheet.create(opts, function(err, spreadsheet) {
-          spreadsheet.init(function(err) {
-            expect(err).to.not.exist();
-            expect(mockRequest).to.have.been.calledWith('stuff');
-            expect(true).to.be.false;
-            done();
-          });
-        });
-      });
-      it('should get the worksheet id');
-    });
-    describe('log', function() {
-      it('should be tested');
-    });
-    describe('getSheetId', function() {
-      it('should be tested');
-    });
-    describe('setToken', function() {
-      it('should be tested');
-    });
-    describe('reset', function() {
-      it('should be tested');
-    });
-    describe('add', function() {
-      it('should be tested');
-    });
-    describe('arr', function() {
-      it('should be tested');
-    });
-    describe('obj', function() {
-      it('should be tested');
-    });
-    describe('getNames', function() {
-      it('should be tested');
-    });
-    describe('addVal', function() {
-      it('should be tested');
-    });
-    describe('compile', function() {
-      it('should be tested');
-    });
-    describe('send', function() {
-      it('should be tested');
-    });
-    describe('receive', function() {
-      it('should be tested');
-    });
-    describe('metadata', function() {
-      it('should be tested');
     });
   });
 });

--- a/test/spreadsheet.js
+++ b/test/spreadsheet.js
@@ -1,0 +1,298 @@
+var chai = require('chai');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+var expect = chai.expect;
+var mockery = require('mockery');
+
+var mockRequestCbParams = {
+  err: null,
+  response: { statusCode: 200 },
+  body: {}
+};
+var mockRequest = sinon.spy(function(opts, callback) {
+  callback(
+    mockRequestCbParams.err,
+    mockRequestCbParams.response,
+    mockRequestCbParams.body
+  );
+});
+
+var mockAuth = sinon.spy(function(opts, callback) { callback(null, 'mockToken'); });
+
+var opts = {
+  oauth2: 'oauth2',
+  spreadsheetId: 'spreadsheetId',
+  worksheetId: 'worksheetId'
+};
+
+
+var Spreadsheet;
+
+describe('Spreadsheet', function() {
+  before(function() {
+
+    mockery.enable({warnOnUnregistered: false});
+
+    mockery.registerMock('request', mockRequest);
+    mockery.registerMock('./auth', mockAuth);
+
+    Spreadsheet = require('../lib/spreadsheet.js');
+  });
+  after(function() {
+    mockery.deregisterAll();
+    mockery.disable();
+  });
+
+  describe('create (alias load)', function() {
+    it('should call the callback', function() {
+      var callback = sinon.spy();
+      Spreadsheet.create({}, callback);
+      expect(callback).to.have.been.calledOnce;
+    });
+    it('should call the opts.callback', function() {
+      var callback = sinon.spy();
+      Spreadsheet.create({callback: callback});
+      expect(callback).to.have.been.calledOnce;
+    });
+    it('should throw an error if there is no callback', function() {
+      expect(function() {
+        Spreadsheet.create({});
+      }).to.throw(Error)
+    });
+    it('should return an error if there is no auth mechanism', function() {
+      var errValue;
+      var callback = sinon.spy(function(err) {errValue = err;});
+      Spreadsheet.create({spreadsheetId: 'spreadsheetId', worksheetId: 'worksheetId'}, callback);
+      expect(callback).to.have.been.calledOnce;
+      expect(errValue).to.be.an.instanceof(Error);
+      expect(Error.message).to.equal('Missing authentication information');
+    });
+    it('should return an error if there is no spreadsheet specified', function() {
+      var errValue;
+      var callback = sinon.spy(function(err) {errValue = err;});
+      Spreadsheet.create({oauth2: 'oauth2', worksheetId: 'worksheetId'}, callback);
+      expect(callback).to.have.been.calledOnce;
+      expect(errValue).to.be.an.instanceof(Error);
+      expect(Error.message).to.equal("Missing 'spreadsheetId' or 'spreadsheetName'");
+    });
+    it('should return an error if there is no worksheet specified', function() {
+      var errValue;
+      var callback = sinon.spy(function(err) {errValue = err;});
+      Spreadsheet.create({oauth2: 'oauth2', spreadsheetId: 'spreadsheetId'}, callback);
+      expect(callback).to.have.been.calledOnce;
+      expect(errValue).to.be.an.instanceof(Error);
+      expect(Error.message).to.equal("Missing 'worksheetId' or 'worksheetName'");
+    });
+    describe('when authing with defaults', function() {
+      var authParams;
+      before(function(done) {
+        mockAuth.reset();
+        Spreadsheet.create(opts, function() {
+          authParams = mockAuth.args[0][0];
+          done();
+        });
+      });
+      it('should default to use cell text values', function() {
+        expect(authParams.useCellTextValues).to.be.true;
+      });
+      it('should default to https', function() {
+        expect(authParams.useHTTPS).to.equal('s');
+      });
+      it('should pass the specified parameters', function() {
+        expect(authParams.oauth2).to.equal('oauth2');
+        expect(authParams.spreadsheetId).to.equal('spreadsheetId');
+        expect(authParams.worksheetId).to.equal('worksheetId');
+      });
+    });
+    it('should be able to override use cell text values', function(done) {
+      mockAuth.reset();
+      var opts = {
+        oauth2: 'oauth2',
+        spreadsheetId: 'spreadsheetId',
+        worksheetId: 'worksheetId',
+        useCellTextValues: false
+      };
+      Spreadsheet.create(opts, function() {
+        expect(mockAuth.args[0][0].useCellTextValues).to.be.false;
+        done();
+      });
+    });
+    it('should be able to override use HTTPS', function(done) {
+      mockAuth.reset();
+      var opts = {
+        oauth2: 'oauth2',
+        spreadsheetId: 'spreadsheetId',
+        worksheetId: 'worksheetId',
+        useHTTPS: false
+      };
+      Spreadsheet.create(opts, function() {
+        expect(mockAuth.args[0][0].useHTTPS).to.be.empty;
+        done();
+      });
+    });
+    it('should pass back an initialized spreadsheet instance', function(done) {
+      Spreadsheet.create(opts, function(err, spreadsheet) {
+        expect(err).to.not.exist;
+        expect(spreadsheet.spreadsheetId).to.equal('spreadsheetId');
+        expect(spreadsheet.worksheetId).to.equal('worksheetId');
+        expect(spreadsheet.protocol).to.equal('https');
+        done();
+      });
+    });
+  });
+
+  describe('spreadsheet', function() {
+    var spreadsheet;
+
+    before(function(done) {
+      Spreadsheet.create(opts, function(err, createdSheet) {
+        spreadsheet = createdSheet;
+        done();
+      });
+    });
+
+    describe('request', function() {
+      var opts = {
+        url: 'https://example.com'
+      };
+      beforeEach(function() {
+        mockRequestCbParams = {
+          err: null,
+          response: { statusCode: 200 },
+          body: {},
+          headers: { 'content-type': 'application/atom+xml; charset=UTF-8; type=feed' }
+        };
+      });
+      it('should return an error if no URL is provided', function(done) {
+        spreadsheet.request({}, function(err, response) {
+          expect(err).to.be.an.instanceof(Error);
+          done();
+        });
+      });
+      it('should return an error if the request fails (ie. timeout)', function(done) {
+        mockRequestCbParams.err = new Error('ETIMEDOUT');
+        spreadsheet.request(opts, function(err, response) {
+          expect(err).to.be.an.instanceof(Error);
+          done();
+        });
+      });
+      it('should return an error if the server does not respond', function(done) {
+        mockRequestCbParams.response = undefined;
+        spreadsheet.request(opts, function(err, response) {
+          expect(err).to.be.an.instanceof(Error);
+          done();
+        });
+      });
+      it('should return an error if the server returns with an unexpected content type', function(done) {
+        mockRequestCbParams.response.headers = { 'content-type': 'image/svg+xml; charset=utf-8' };
+        spreadsheet.request(opts, function(err, response) {
+          expect(err).to.be.an.instanceof(Error);
+          done();
+        });
+      });
+      it('should return an error if the server returns an error', function(done) {
+        mockRequestCbParams.response.statusCode = 500;
+        mockRequestCbParams.body = 'Something broke.';
+        spreadsheet.request(opts, function(err, response) {
+          expect(err).to.be.an.instanceof(Error);
+          expect(err.message).to.be('Something broke.');
+          done();
+        });
+      });
+      it('should parse text elements', function(done) {
+        mockRequestCbParams.body = '<title>Income</title>';
+        spreadsheet.request(opts, function(err, response) {
+          expect(response.title).to.equal('Income');
+          done();
+        });
+      });
+      it('should parse numeric integer elements', function(done) {
+        mockRequestCbParams.body = '<gs:rowCount>45</gs:rowCount>';
+        spreadsheet.request(opts, function(err, response) {
+          expect(response['gs:rowCount']).to.equal(45);
+          done();
+        });
+      });
+      it('should parse numeric floating elements', function(done) {
+        mockRequestCbParams.body = "<gs:cell row='85' col='6' inputValue='=R[0]C[-1]/R[0]C[-2]' numericValue='1.2'>1.20</gs:cell>";
+        spreadsheet.request(opts, function(err, response) {
+          console.log(response);
+          expect(response['gs:cell']).to.equal(1.2);
+          done();
+        });
+      });
+      it('should parse text attributes', function(done) {
+        mockRequestCbParams.body = "<batch:status code='200' reason='Success'/>";
+        spreadsheet.request(opts, function(err, response) {
+          expect(response['batch:status'].reason).to.equal('Success');
+          done();
+        });
+      });
+      it('should parse numeric integer attributes', function(done) {
+        mockRequestCbParams.body = "<batch:status code='200' reason='Success'/>";
+        spreadsheet.request(opts, function(err, response) {
+          expect(response['batch:status'].code).to.equal(200);
+          expect(response['batch:status'].code).to.be.a('number');
+          done();
+        });
+      });
+      it('should parse numeric float attributes', function(done) {
+        mockRequestCbParams.body = "<gs:cell row='85' col='6' inputValue='=R[0]C[-1]/R[0]C[-2]' numericValue='1.2'>1.20</gs:cell>";
+        spreadsheet.request(opts, function(err, response) {
+          expect(response['gs:cell'].numericValue).to.equal(1.2);
+          expect(response['gs:cell'].numericValue).to.be.a('number');
+          done();
+        });
+      });
+    });
+    describe('init', function() {
+      it('should be tested');
+    });
+    describe('log', function() {
+      it('should be tested');
+    });
+    describe('getSheetId', function() {
+      it('should be tested');
+    });
+    describe('setToken', function() {
+      it('should be tested');
+    });
+    describe('baseUrl', function() {
+      it('should be tested');
+    });
+    describe('setTemplates', function() {
+      it('should be tested');
+    });
+    describe('reset', function() {
+      it('should be tested');
+    });
+    describe('add', function() {
+      it('should be tested');
+    });
+    describe('arr', function() {
+      it('should be tested');
+    });
+    describe('obj', function() {
+      it('should be tested');
+    });
+    describe('getNames', function() {
+      it('should be tested');
+    });
+    describe('addVal', function() {
+      it('should be tested');
+    });
+    describe('compile', function() {
+      it('should be tested');
+    });
+    describe('send', function() {
+      it('should be tested');
+    });
+    describe('receive', function() {
+      it('should be tested');
+    });
+    describe('metadata', function() {
+      it('should be tested');
+    });
+  });
+});


### PR DESCRIPTION
This PR is based on #83 opened by @gregaubert, with the addition of some additional configuration for a newer version of xml2js that handles attribute values in a manner compatible with the version of xml2json that was originally used here.

I needed to do this to remove the expat module that was built with permissions that Amazon Inspector was warning about, and @gregaubert indicated in PR #83, it is required for Node 4 compatibility.

I also added a set of unit tests for verification, which might make a nice framework for more unit tests for any other updates, new features, or refectoring.

