### PR TITLE
Dependency update

### DIFF
--- a/get_oauth2_permissions.js
+++ b/get_oauth2_permissions.js
@@ -19,7 +19,8 @@
 
 var readline = require('readline');
 
-var OAuth2Client = require('google-auth-library').OAuth2;
+var googleAuth = require('google-auth-library');
+var OAuth2Client = new googleAuth().OAuth2;
 
 // Client ID and client secret are available at
 // https://code.google.com/apis/console

--- a/get_oauth2_permissions.js
+++ b/get_oauth2_permissions.js
@@ -19,8 +19,7 @@
 
 var readline = require('readline');
 
-var google = require('googleapis');
-var OAuth2Client = google.auth.OAuth2;
+var OAuth2Client = require('google-auth-library').OAuth2;
 
 // Client ID and client secret are available at
 // https://code.google.com/apis/console
@@ -68,4 +67,3 @@ rl.question('Enter the code here: ', function(code) {
     process.exit(0);
   });
 });
-

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,7 @@
 var GoogleClientLogin = require('googleclientlogin').GoogleClientLogin;
 var GoogleOAuthJWT = require('google-oauth-jwt');
-var GoogleOAuthClient = require('google-auth-library').OAuth2;
+var googleAuth = require('google-auth-library');
+var GoogleOAuthClient = new googleAuth().OAuth2;
 
 //client auth helper
 module.exports = function(opts, done) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,6 +1,6 @@
 var GoogleClientLogin = require('googleclientlogin').GoogleClientLogin;
 var GoogleOAuthJWT = require('google-oauth-jwt');
-var GoogleOAuthClient = require('googleapis').auth.OAuth2;
+var GoogleOAuthClient = require('google-auth-library').OAuth2;
 
 //client auth helper
 module.exports = function(opts, done) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "colors": "^1.0.3",
     "google-auth-library": "^0.9.6",
     "google-oauth-jwt": "~0.1.4",
-    "googleclientlogin": "~0.2.6",
+    "googleclientlogin": "~0.2.8",
     "lodash": "^3.10.1",
     "request": "^2.51.0",
     "xml2js": "^0.4.15"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
     "test": "mocha test --recursive"
   },
   "dependencies": {
-    "async": "^0.9.0",
+    "async": "^1.5.0",
     "colors": "^1.0.3",
+    "google-auth-library": "^0.9.6",
     "google-oauth-jwt": "~0.1.4",
-    "googleapis": "2.0.4",
     "googleclientlogin": "~0.2.6",
-    "lodash": "^2.4.1",
+    "lodash": "^3.10.1",
     "request": "^2.51.0",
     "xml2js": "^0.4.15"
   },


### PR DESCRIPTION
This PR updates the dependencies and replaces the full Google API module with the more narrowly scoped auth-only module in the interest of footprint and tracking only relevant changes (googleapis is huge).

Hypothetically this should lower the footprint and remove some of the 'yellow' from the dependency indicator in the readme, currently as well as going forward as Google updates unrelated APIs.

I've tested it within my application on Node 0.12.7, 4.0.0, and 5.1.0 using both the OAuth2 (method 3 in the README) and dynamic token (method 5 in the readme) auth methods, but I'd feel a little better about merging this if some other folks could also put a little mileage on it in their own application first.
