### PR TITLE
Remove 'DUMMY' default access token value in oauth2 client

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -52,7 +52,6 @@ function oAuth2Login(oauth2, done ) {
   var oAuth2Client = new GoogleOAuthClient(oauth2.client_id, oauth2.client_secret, 'urn:ietf:wg:oauth:2.0:oob');
 
   oAuth2Client.setCredentials({
-    access_token: 'DUMMY',
     expiry_date: 1,
     refresh_token: oauth2.refresh_token,
     token_type: 'Bearer'


### PR DESCRIPTION
Hello,

I noticed a case leading to an infinite loop when using oauth2 logging without a refresh_token.

It can be reproduced by using `get_oauth2_permissions.js` utility, removing the refresh_token from `oauth2-creds.json` and running `read-basic.js` example.

Note that this only happens when you remove the refresh_token, not if you just set it to a wrong value.

The problem is that we're setting the value 'DUMMY' as the oauth2 client's access token before requesting for an actual access token (See [auth.js l.54](https://github.com/jpillora/node-edit-google-spreadsheet/blob/master/lib/auth.js#L54)). This means the client won't even request Google and will return the 'DUMMY' token right away. Then the requests for data will return _401_ due to the wrong access token, triggering the re-authenticate workflow forever.

I can't see any reason for this 'DUMMY' value, and I think it can be removed. What do you think @cybic?
